### PR TITLE
Columns ordered in Containers CSV Export

### DIFF
--- a/fms_core/serializers.py
+++ b/fms_core/serializers.py
@@ -38,7 +38,7 @@ class ContainerExportSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Container
-        fields = ('kind', 'name', 'barcode', 'location', 'coordinates', 'comment')
+        fields = ('name', 'kind', 'barcode', 'location', 'coordinates', 'comment')
 
 
 class IndividualSerializer(serializers.ModelSerializer):

--- a/fms_core/serializers.py
+++ b/fms_core/serializers.py
@@ -35,10 +35,16 @@ class SimpleContainerSerializer(serializers.ModelSerializer):
 
 class ContainerExportSerializer(serializers.ModelSerializer):
     location = serializers.SlugRelatedField(slug_field='barcode', read_only=True)
+    container_kind = serializers.CharField(source='kind')
 
     class Meta:
         model = Container
-        fields = ('name', 'kind', 'barcode', 'location', 'coordinates', 'comment')
+        fields = ('name', 'container_kind', 'barcode', 'location', 'coordinates', 'comment')
+
+    def to_representation(self, obj):
+        primitive_repr = super(ContainerExportSerializer, self).to_representation(obj)
+        primitive_repr = {k.replace("_", " "): v for k, v in primitive_repr.items()}
+        return primitive_repr
 
 
 class IndividualSerializer(serializers.ModelSerializer):

--- a/fms_core/serializers.py
+++ b/fms_core/serializers.py
@@ -61,8 +61,8 @@ class SampleExportSerializer(serializers.ModelSerializer):
     sex = serializers.CharField(read_only=True, source="individual.sex")
     pedigree = serializers.CharField(read_only=True, source="individual.pedigree")
     cohort = serializers.CharField(read_only=True, source="individual.cohort")
-    mother_id = serializers.SerializerMethodField()
-    father_id = serializers.SerializerMethodField()
+    mother_name = serializers.SerializerMethodField()
+    father_name = serializers.SerializerMethodField()
     container_kind = serializers.CharField(read_only=True, source="container.kind")
     container_name = serializers.CharField(read_only=True, source="container.name")
     container_barcode = serializers.CharField(read_only=True, source="container.barcode")
@@ -74,7 +74,7 @@ class SampleExportSerializer(serializers.ModelSerializer):
         model = Sample
         fields = ('biospecimen_type', 'sample_name', 'alias', 'cohort', 'taxon',
                   'container_kind', 'container_name', 'container_barcode', 'location_barcode', 'location_coord',
-                  'individual_id', 'sex', 'pedigree', 'mother_id', 'father_id',
+                  'individual_id', 'sex', 'pedigree', 'mother_name', 'father_name',
                   'current_volume', 'concentration', 'collection_site', 'tissue_source', 'reception_date', 'phenotype',
                   'depleted', 'coordinates',
                   'comment')
@@ -89,11 +89,11 @@ class SampleExportSerializer(serializers.ModelSerializer):
         sorted_volume_histories = sorted(obj.volume_history, key=lambda k: k['date'])
         return sorted_volume_histories[-1]['volume_value']
 
-    def get_father_id(self, obj):
+    def get_father_name(self, obj):
         father = '' if obj.individual.father is None else obj.individual.father.name
         return father
 
-    def get_mother_id(self, obj):
+    def get_mother_name(self, obj):
         mother = '' if obj.individual.mother is None else obj.individual.mother.name
         return mother
 

--- a/fms_core/serializers.py
+++ b/fms_core/serializers.py
@@ -41,11 +41,6 @@ class ContainerExportSerializer(serializers.ModelSerializer):
         model = Container
         fields = ('name', 'container_kind', 'barcode', 'location', 'coordinates', 'comment')
 
-    def to_representation(self, obj):
-        primitive_repr = super(ContainerExportSerializer, self).to_representation(obj)
-        primitive_repr = {k.replace("_", " "): v for k, v in primitive_repr.items()}
-        return primitive_repr
-
 
 class IndividualSerializer(serializers.ModelSerializer):
     class Meta:
@@ -101,11 +96,6 @@ class SampleExportSerializer(serializers.ModelSerializer):
     def get_mother_id(self, obj):
         mother = '' if obj.individual.mother is None else obj.individual.mother.name
         return mother
-
-    def to_representation(self, obj):
-        primitive_repr = super(SampleExportSerializer, self).to_representation(obj)
-        primitive_repr = {k.replace("_", " "): v for k, v in primitive_repr.items()}
-        return primitive_repr
 
 
 class NestedSampleSerializer(serializers.ModelSerializer):

--- a/fms_core/viewsets.py
+++ b/fms_core/viewsets.py
@@ -291,7 +291,7 @@ class ContainerViewSet(viewsets.ModelViewSet, TemplateActionsMixin):
 
     def get_renderer_context(self):
         context = super().get_renderer_context()
-        context['header'] = ContainerExportSerializer.Meta.fields
+        context['header'] = ContainerExportSerializer.Meta.fields if self.action == 'list_export' else None
         return context
 
     @action(detail=False, methods=["get"])

--- a/fms_core/viewsets.py
+++ b/fms_core/viewsets.py
@@ -289,6 +289,11 @@ class ContainerViewSet(viewsets.ModelViewSet, TemplateActionsMixin):
         },
     ]
 
+    def get_renderer_context(self):
+        context = super().get_renderer_context()
+        context['header'] = ContainerExportSerializer.Meta.fields
+        return context
+
     @action(detail=False, methods=["get"])
     def summary(self, _request):
         """

--- a/fms_core/viewsets.py
+++ b/fms_core/viewsets.py
@@ -291,7 +291,8 @@ class ContainerViewSet(viewsets.ModelViewSet, TemplateActionsMixin):
 
     def get_renderer_context(self):
         context = super().get_renderer_context()
-        context['header'] = ContainerExportSerializer.Meta.fields if self.action == 'list_export' else None
+        if self.action == 'list_export':
+            context['header'] = [field.replace("_", " ") for field in ContainerExportSerializer.Meta.fields]
         return context
 
     @action(detail=False, methods=["get"])

--- a/fms_core/viewsets.py
+++ b/fms_core/viewsets.py
@@ -437,6 +437,14 @@ class SampleViewSet(viewsets.ModelViewSet, TemplateActionsMixin):
             return NestedSampleSerializer
         return SampleSerializer
 
+
+    def get_renderer_context(self):
+        context = super().get_renderer_context()
+        if self.action == 'list_export':
+            context['header'] = [field.replace("_", " ") for field in SampleExportSerializer.Meta.fields]
+        return context
+
+
     @action(detail=False, methods=["get"])
     def list_export(self, _request):
         serializer = SampleExportSerializer(self.filter_queryset(self.get_queryset()), many=True)

--- a/fms_core/viewsets.py
+++ b/fms_core/viewsets.py
@@ -292,7 +292,7 @@ class ContainerViewSet(viewsets.ModelViewSet, TemplateActionsMixin):
     def get_renderer_context(self):
         context = super().get_renderer_context()
         if self.action == 'list_export':
-            context['header'] = [field.replace("_", " ") for field in ContainerExportSerializer.Meta.fields]
+            context['header'] = ContainerExportSerializer.Meta.fields
         return context
 
     @action(detail=False, methods=["get"])
@@ -441,7 +441,7 @@ class SampleViewSet(viewsets.ModelViewSet, TemplateActionsMixin):
     def get_renderer_context(self):
         context = super().get_renderer_context()
         if self.action == 'list_export':
-            context['header'] = [field.replace("_", " ") for field in SampleExportSerializer.Meta.fields]
+            context['header'] = SampleExportSerializer.Meta.fields
         return context
 
 


### PR DESCRIPTION
It does work but I am not sure this is the best 'Django' way of doing it (overriding the get_renderer_context method which gets called because we use the CSV renderer from django_rest_framework_csv, and setting up a context columns 'header' if the action is list_export.... )