### PR TITLE
Add distinction between header and labels for columns in renderer

### DIFF
--- a/fms_core/viewsets.py
+++ b/fms_core/viewsets.py
@@ -292,7 +292,9 @@ class ContainerViewSet(viewsets.ModelViewSet, TemplateActionsMixin):
     def get_renderer_context(self):
         context = super().get_renderer_context()
         if self.action == 'list_export':
-            context['header'] = ContainerExportSerializer.Meta.fields
+            fields = ContainerExportSerializer.Meta.fields
+            context['header'] = fields
+            context['labels'] = {i: i.replace('_', ' ').capitalize() for i in fields}
         return context
 
     @action(detail=False, methods=["get"])
@@ -441,7 +443,9 @@ class SampleViewSet(viewsets.ModelViewSet, TemplateActionsMixin):
     def get_renderer_context(self):
         context = super().get_renderer_context()
         if self.action == 'list_export':
-            context['header'] = SampleExportSerializer.Meta.fields
+            fields = SampleExportSerializer.Meta.fields
+            context['header'] = fields
+            context['labels'] = {i: i.replace('_', ' ').capitalize() for i in fields}
         return context
 
 


### PR DESCRIPTION
Simplest solution for distinguishing headers and labels, in the context of rendering CSV