### PR TITLE
Modify samples serializers

### DIFF
--- a/fms_core/serializers.py
+++ b/fms_core/serializers.py
@@ -49,10 +49,12 @@ class IndividualSerializer(serializers.ModelSerializer):
 
 
 class SampleSerializer(serializers.ModelSerializer):
+    container__name = serializers.CharField(read_only=True, source="container.name")
+
     class Meta:
         model = Sample
         fields = "__all__"
-
+        extra_fields = ['container__name']
 
 class SampleExportSerializer(serializers.ModelSerializer):
     sample_name = serializers.CharField(source="name")
@@ -103,10 +105,12 @@ class NestedSampleSerializer(serializers.ModelSerializer):
     individual = IndividualSerializer(read_only=True)
     container = SimpleContainerSerializer(read_only=True)
     extracted_from = SampleSerializer(read_only=True)
+    container__name = serializers.CharField(read_only=True, source="container.name")
 
     class Meta:
         model = Sample
         fields = "__all__"
+        extra_fields = ['container__name']
 
 
 class VersionSerializer(serializers.ModelSerializer):

--- a/fms_core/serializers.py
+++ b/fms_core/serializers.py
@@ -50,11 +50,12 @@ class IndividualSerializer(serializers.ModelSerializer):
 
 class SampleSerializer(serializers.ModelSerializer):
     container__name = serializers.CharField(read_only=True, source="container.name")
+    individual__name = serializers.CharField(read_only=True, source="individual.name")
 
     class Meta:
         model = Sample
         fields = "__all__"
-        extra_fields = ['container__name']
+        extra_fields = ['container__name', 'individual__name']
 
 class SampleExportSerializer(serializers.ModelSerializer):
     sample_name = serializers.CharField(source="name")
@@ -106,11 +107,12 @@ class NestedSampleSerializer(serializers.ModelSerializer):
     container = SimpleContainerSerializer(read_only=True)
     extracted_from = SampleSerializer(read_only=True)
     container__name = serializers.CharField(read_only=True, source="container.name")
+    individual__name = serializers.CharField(read_only=True, source="individual.name")
 
     class Meta:
         model = Sample
         fields = "__all__"
-        extra_fields = ['container__name']
+        extra_fields = ['container__name', 'individual__name']
 
 
 class VersionSerializer(serializers.ModelSerializer):


### PR DESCRIPTION
Even though we are using nested serializers, it seems like I have to declare the extra_fields myself (container__name, individual__name), otherwise the sorting is done automatically on the ID of the container, and the ID of the individual, and not on their name.

See https://github.com/c3g/freezeman_web/pull/28